### PR TITLE
[BUGFIX] Initialize purge_all variable

### DIFF
--- a/.travis/default-site.tpl.conf
+++ b/.travis/default-site.tpl.conf
@@ -51,6 +51,7 @@ server {
         set $purge_path "/tmp/cache";
         set $purge_levels "1:2";
         set $purge_cache_key "$scheme://$host:$server_port$request_uri";
+        set $purge_all 0;
         if ($request_uri = /*) {
             set $purge_all 1;
         }

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,7 @@ And in your php location you need to configure the desired cache behaviour:
         set $purge_path "/var/nginx/cache/TYPO3";
         set $purge_levels "1:2";
         set $purge_cache_key "$scheme://$host$request_uri";
+        set $purge_all 0;
         if ($request_uri = /*) {
             set $purge_all 1;
         }

--- a/Resources/Private/nginx_purge/purge.pm
+++ b/Resources/Private/nginx_purge/purge.pm
@@ -76,6 +76,7 @@ __END__
 #            set $purge_path "/tmp/cache1";
 #            set $purge_levels "1:2";
 #            set $purge_cache_key "http://dev$request_uri";
+#            set $purge_all 0;
 #            if ($request_uri = /*) {
 #                set $purge_all 1;
 #            }

--- a/Resources/Private/nginx_purge/purge.pm
+++ b/Resources/Private/nginx_purge/purge.pm
@@ -17,7 +17,7 @@ sub handler {
     }
     $r->send_http_header('text/plain');
 
-    if ($r->variable('purge_all')) {
+    if ($r->variable('purge_all') == 1) {
         # Make extra sure we don't delete the entire system (or at least those files writable by nginx)
         # in case of a possible configuration mistake (e.g. if $path is empty),
         # by searching for filenames with 32 chars.


### PR DESCRIPTION
Updated documentation to include the initialization of the purge_all
variable, so the default value is 0

Adjusted to purge.pm perl script, so it only purges the whole cache,
when purge_all variable is 1

Without that config, nginx error log is filled with warnings like
shown below

```
[warn] 28314#28314: *58798 using uninitialized "purge_all"
```