### PR TITLE
Moved X-Cache header out of location context

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,10 @@ And in your php location you need to configure the desired cache behaviour:
         fastcgi_cache_valid 0;
         # Ignore all cache headers, besides X-Accel-Expires
         fastcgi_ignore_headers "Expires" "Cache-Control" "Vary";
-
-        # For debugging only
-        add_header X-Cache  $upstream_cache_status;
     }
+
+    # For debugging only
+    add_header X-Cache  $upstream_cache_status;
 
     location @purge {
         allow 127.0.0.1;


### PR DESCRIPTION
Although the `X-Cache` declaration currently is commented as "For debugging only", I recommend to move it out of the `location` context to avoid a misconfiguration, since the current declaration will remove all `add_header` declarations from previous levels (see http://nginx.org/en/docs/http/ngx_http_headers_module.html)