### PR TITLE
[BUGFIX] Fixed wrong cache registration

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -13,8 +13,8 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nginx_cach
     ],
 ];
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/cache/frontend/class.t3lib_cache_frontend_variablefrontend.php']['set'][$_EXTKEY] =
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/cache/frontend/class.t3lib_cache_frontend_variablefrontend.php']['set']['nginx_cache'] =
     \Qbus\NginxCache\Hooks\SetPageCacheHook::class . '->set';
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['pageLoadedFromCache'][$_EXTKEY] =
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['pageLoadedFromCache']['nginx_cache'] =
     \Qbus\NginxCache\Hooks\PageLoadedFromCacheHook::class . '->loadedFromCache';


### PR DESCRIPTION
`$_EXTKEY` is not available any more in TYPO3 10.