### PR TITLE
Fix #14: Fix cache clearing of a single page

### DIFF
--- a/Classes/Cache/Backend/NginxCacheBackend.php
+++ b/Classes/Cache/Backend/NginxCacheBackend.php
@@ -109,6 +109,17 @@ class NginxCacheBackend extends \TYPO3\CMS\Core\Cache\Backend\Typo3DatabaseBacke
     }
 
     /**
+     * Removes all cache entries of this cache which are tagged by any of the specified tags.
+     *
+     * @param string[] $tags List of tags
+     * @return void
+     */
+    public function flushByTags(array $tags)
+    {
+        array_walk($tags, [$this, 'flushByTag']);
+    }
+
+    /**
      * @param  string $url
      * @return string
      */


### PR DESCRIPTION
The TYPO3 cache manager calls flushByTags instead of flushByTag of all third-party caches which implement TaggableBackendInterface thus simply copy in the \TYPO3\CMS\Core\Cache\Backend\AbstractBackend::flushByTags implementation.