### PR TITLE
[TASK] Ensure TYPO3 404 page is not cached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ cache:
 before_install:
   - echo $TRAVIS_PHP_VERSION
   - if php -i | grep -q xdebug; then phpenv config-rm xdebug.ini; fi
-  - composer self-update
+  - composer self-update --1
   - composer --version
   - wget https://raw.github.com/lehmannro/assert.sh/v1.1/assert.sh -O .travis/assert.sh
 

--- a/Classes/Hooks/SetPageCacheHook.php
+++ b/Classes/Hooks/SetPageCacheHook.php
@@ -15,9 +15,11 @@ namespace Qbus\NginxCache\Hooks;
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * SetPageCacheHook
@@ -145,18 +147,18 @@ class SetPageCacheHook
     }
 
     /**
-     * @return \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController
+     * @return TypoScriptFrontendController|null
      */
     protected function getTypoScriptFrontendController()
     {
-        return $GLOBALS['TSFE'];
+        return isset($GLOBALS['TSFE']) ? $GLOBALS['TSFE'] : null;
     }
 
     /**
-     * @return \TYPO3\CMS\Core\Cache\CacheManager;
+     * @return CacheManager
      */
     protected function getCacheManager()
     {
-        return GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class);
+        return GeneralUtility::makeInstance(CacheManager::class);
     }
 }

--- a/Classes/Hooks/SetPageCacheHook.php
+++ b/Classes/Hooks/SetPageCacheHook.php
@@ -45,6 +45,11 @@ class SetPageCacheHook
             return;
         }
 
+        // Ignore TYPO3 v9+ cached 404 page
+        if (in_array('errorPage', $params['tags'], true)) {
+            return;
+        }
+
         // TYPO3 v9 added none-page content to cache_pages, ignore those.
         $ignoredIdentifiers = [
             'redirects',
@@ -67,6 +72,7 @@ class SetPageCacheHook
 
         $isLaterCachable = (
             $temp_content === false &&
+            $tsfe &&
             $tsfe->isStaticCacheble() &&
             $tsfe->doWorkspacePreview() === false &&
             $this->isFrontendEditingActive() === false &&


### PR DESCRIPTION
Since TYPO3 10.4.14 the content of a 404 page using the PageContentErrorHandler is cached in the TYPO3 page cache.

As a result, the 404 page should not be cached in nginx cache and additionally it must be ensured that TSFE is available before TSFE methods are called.